### PR TITLE
fix missing `orderItem.product` in documentation

### DIFF
--- a/doc/implementation-guide/readme.md
+++ b/doc/implementation-guide/readme.md
@@ -70,12 +70,13 @@ Chrome and Chrome-based browsers may not show responses for failed requests, so 
 
 `orderItem`:
 
-* `id`
-  * required, string
-  * your product ID, must match the ID you are using in XML feed provided to FAVI
-* `name`
-  * required, string
-  * your product name, must match the name you are using in XML feed provided to FAVI
+* `product` - required, object:
+  * `id`
+    * required, string
+    * your product ID, must match the ID you are using in XML feed provided to FAVI
+  * `name`
+    * required, string
+    * your product name, must match the name you are using in XML feed provided to FAVI
 
 `customer`:
 


### PR DESCRIPTION
See https://github.com/favionline/partner-events-tracking/blob/581d644422b958c5c239ebb75fa09a4b278b42dc/doc/implementation-guide/client-direct.md#createorder-event where it is documented correctly.